### PR TITLE
Make sure other protocols aren't parsed in CSS URLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ class DissectHtml {
     const self = this
     // to get -> property: url(filepath)
 
-    const processed = text.replace(/url\(["']?([^"')]+?)["']?\)/ig, function (_u, url) {
+    const processed = text.replace(/url\(["']?((?!.*:\/\/|"|'|\)).+?)["']?\)/ig, function (_u, url) {
       // to get -> filepath from url(filepath), url('filepath') and url('filepath')
       return `url(${self._changeRelUrl(url, path.dirname(cssBasePath))})`
     })


### PR DESCRIPTION
URLs that are to CDNs (Google fonts in my case) were parsed as file URLs which didn't make sense and threw errors. This patch makes sure only URLs without a protocol pointer (://) are parsed as files and the others are left alone.